### PR TITLE
Use constant for current scene ready event

### DIFF
--- a/src/game/PhaserGame.tsx
+++ b/src/game/PhaserGame.tsx
@@ -39,7 +39,7 @@ export const PhaserGame = forwardRef<
   }, [ref])
 
   useEffect(() => {
-    EventBus.on(EVENT_CURRENT_SCENE_READY, (scene_instance: Phaser.Scene) => {
+    const handleSceneReady = (scene_instance: Phaser.Scene) => {
       if (currentActiveScene && typeof currentActiveScene === 'function') {
         currentActiveScene(scene_instance)
       }
@@ -49,9 +49,11 @@ export const PhaserGame = forwardRef<
       } else if (ref) {
         ref.current = { game: game.current, scene: scene_instance }
       }
-    })
+    }
+
+    EventBus.on(EVENT_CURRENT_SCENE_READY, handleSceneReady)
     return () => {
-      EventBus.removeListener(EVENT_CURRENT_SCENE_READY)
+      EventBus.removeListener(EVENT_CURRENT_SCENE_READY, handleSceneReady)
     }
   }, [currentActiveScene, ref])
 

--- a/src/game/PhaserGame.tsx
+++ b/src/game/PhaserGame.tsx
@@ -2,6 +2,7 @@ import { forwardRef, useEffect, useLayoutEffect, useRef } from 'react'
 import StartGame from './main'
 
 import { EventBus } from '@/lib/shared/EventBus'
+import { EVENT_CURRENT_SCENE_READY } from '@/lib/shared/EventBusEvents'
 
 export interface IRefPhaserGame {
   game: Phaser.Game | null
@@ -38,7 +39,7 @@ export const PhaserGame = forwardRef<
   }, [ref])
 
   useEffect(() => {
-    EventBus.on('current-scene-ready', (scene_instance: Phaser.Scene) => {
+    EventBus.on(EVENT_CURRENT_SCENE_READY, (scene_instance: Phaser.Scene) => {
       if (currentActiveScene && typeof currentActiveScene === 'function') {
         currentActiveScene(scene_instance)
       }
@@ -50,7 +51,7 @@ export const PhaserGame = forwardRef<
       }
     })
     return () => {
-      EventBus.removeListener('current-scene-ready')
+      EventBus.removeListener(EVENT_CURRENT_SCENE_READY)
     }
   }, [currentActiveScene, ref])
 

--- a/src/lib/shared/EventBusEvents.ts
+++ b/src/lib/shared/EventBusEvents.ts
@@ -1,3 +1,4 @@
 export const EVENT_STEP_COUNT_UPDATED = 'step-count-updated'
 export const EVENT_LEVEL_UPDATED = 'level-updated'
+export const EVENT_CURRENT_SCENE_READY = 'current-scene-ready'
 // Add more event constants here as needed


### PR DESCRIPTION
## Summary
- define `EVENT_CURRENT_SCENE_READY` constant
- use this constant in `PhaserGame`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68532d8830748322862357431895d5e9