### PR TITLE
Fix maze redraw bug

### DIFF
--- a/src/game/Maze.ts
+++ b/src/game/Maze.ts
@@ -9,6 +9,7 @@ export class Maze {
   rows: number
   grid: number[][]
   scene: Phaser.Scene
+  graphics: Phaser.GameObjects.Graphics | null = null
   start: { x: number; y: number } = { x: 0, y: 0 }
   end: { x: number; y: number } = { x: 0, y: 0 }
   totalCells: number // How many cells should be used in the maze
@@ -1030,7 +1031,11 @@ export class Maze {
   }
 
   render() {
-    const graphics = this.scene.add.graphics()
+    if (this.graphics) {
+      this.graphics.destroy()
+    }
+    this.graphics = this.scene.add.graphics()
+    const graphics = this.graphics
 
     // First render any cells that are not part of the shape with a light background
     graphics.fillStyle(COLOR_EMPTY, 0.5)
@@ -1181,5 +1186,12 @@ export class Maze {
 
     // Then check if there's no wall between the cells
     return !this.hasWall(x, y, newX, newY)
+  }
+
+  destroy() {
+    if (this.graphics) {
+      this.graphics.destroy()
+      this.graphics = null
+    }
   }
 }

--- a/src/game/MazeScene.ts
+++ b/src/game/MazeScene.ts
@@ -15,6 +15,9 @@ export class MazeScene extends Phaser.Scene {
   }
 
   init() {
+    if (maze) {
+      maze.destroy()
+    }
     // Create maze with more cells to make shapes visible
     maze = new Maze(
       this,
@@ -34,6 +37,9 @@ export class MazeScene extends Phaser.Scene {
 
   handleResize(gameSize: Phaser.Structs.Size) {
     this.cameras.main.setSize(gameSize.width, gameSize.height)
+    if (maze) {
+      maze.destroy()
+    }
     // Create a maze with more cells to make shapes visible
     maze = new Maze(
       this,


### PR DESCRIPTION
## Summary
- clean up maze graphics on restart
- destroy old maze before creating a new one

## Testing
- `npm install`
- `npm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_b_686c6d52fa248320a1e84811d0ffda09