### PR TITLE
Add Jest testing setup

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'jsdom',
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+    '^@/lib/(.*)$': '<rootDir>/src/lib/$1'
+  }
+}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "build-nolog": "next build",
     "dev": "next dev -p 8080",
     "dev-nolog": "next dev -p 8080",
-    "prepare": "husky"
+    "prepare": "husky",
+    "test": "jest"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,mjs}": "prettier --write",
@@ -40,14 +41,18 @@
   },
   "devDependencies": {
     "@brandontom/prettier": "^2.0.0",
+    "@types/jest": "^30.0.0",
     "@types/node": "^20.17.17",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "husky": "^9.1.7",
+    "jest": "^30.0.4",
+    "jest-environment-jsdom": "^30.0.4",
     "lint-staged": "^15.4.3",
     "prettier": "^3.5.0",
     "sort-package-json": "^2.14.0",
     "tailwindcss": "^4.0.5",
+    "ts-jest": "^29.4.0",
     "typescript": "^5.7.3"
   },
   "licenseUrl": "http://www.opensource.org/licenses/mit-license.php"

--- a/tests/MazeShapes.test.ts
+++ b/tests/MazeShapes.test.ts
@@ -1,0 +1,18 @@
+import { MazeShapes } from '@/lib/maze/MazeShapes'
+
+describe('MazeShapes.expandShape', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('expands shape to the desired cell count', () => {
+    const shape = [
+      [true, false],
+      [false, false]
+    ]
+    jest.spyOn(Math, 'random').mockReturnValue(0)
+    const result = MazeShapes.expandShape(shape, 2, 2, 3)
+    const count = result.flat().filter(c => c).length
+    expect(count).toBe(3)
+  })
+})


### PR DESCRIPTION
## Summary
- add Jest and related dev dependencies
- configure Jest with `ts-jest` and jsdom
- add a simple test for `MazeShapes.expandShape`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_686d19daa94483209a57cbefe6592b4b