### PR TITLE
Add Bun-based Docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+.git
+.next
+dist
+coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM oven/bun:latest
+WORKDIR /app
+
+# Install dependencies using bun
+COPY bun.lockb bun.lock package.json ./
+RUN bun install --frozen-lockfile
+
+# Copy rest of the source code
+COPY . .
+
+EXPOSE 8080
+
+CMD ["bun", "run", "dev"]


### PR DESCRIPTION
## Summary
- add a Dockerfile that runs the dev server using Bun
- ignore common build artifacts in `.dockerignore`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686d21613f508320b967f91c7789d8bd