### PR TITLE
Fix release workflow repo-url

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,5 +14,5 @@ jobs:
         with:
           bun-version: "1.2.14"
       - run: bun install
-      - run: bunx release-please release-pr --token ${{ secrets.GITHUB_TOKEN }}
-      - run: bunx release-please github-release --token ${{ secrets.GITHUB_TOKEN }}
+      - run: bunx release-please release-pr --token ${{ secrets.GITHUB_TOKEN }} --repo-url ${{ github.repository }}
+      - run: bunx release-please github-release --token ${{ secrets.GITHUB_TOKEN }} --repo-url ${{ github.repository }}


### PR DESCRIPTION
## Summary
- pass repo URL to release-please commands

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_686d40b566f883208831cc3c75eb4394