### PR TITLE
Fix release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
- ensure the release workflow can create branches and PRs by granting rights

## Testing
- `bun run test`
- `bun x tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_686d476d7ed48320b3c2f79661051491