### PR TITLE
Add player movement throttle and tests

### DIFF
--- a/src/game/Player.ts
+++ b/src/game/Player.ts
@@ -2,13 +2,14 @@ import Phaser from 'phaser'
 import { GameManager } from './GameManager'
 import { Maze } from './Maze'
 import { GridScene } from './GridScene'
-import { COLOR_PLAYER, GRID_SIZE } from '@/game/constants'
+import { COLOR_PLAYER, GRID_SIZE, MOVE_THROTTLE_MS } from '@/game/constants'
 
 export class Player {
   rect: Phaser.GameObjects.Rectangle | null = null
   scene: Phaser.Scene
   cell: { x: number; y: number } = { x: 0, y: 0 }
   private isSquishing = false
+  private lastMoveTime = 0
 
   constructor(scene: Phaser.Scene) {
     this.scene = scene
@@ -57,7 +58,9 @@ export class Player {
   }
 
   moveBy(dx: number, dy: number, maze: Maze) {
-    if (this.isSquishing) return
+    const now = Date.now()
+    if (now - this.lastMoveTime < MOVE_THROTTLE_MS || this.isSquishing) return
+    this.lastMoveTime = now
 
     const newX = this.cell.x + dx
     const newY = this.cell.y + dy

--- a/src/game/constants.ts
+++ b/src/game/constants.ts
@@ -3,3 +3,5 @@ export const COLOR_PLAYER = 0x1952a6 // Dark blue for player
 export const COLOR_MAZE = 0x000000 // Black for maze outline
 export const COLOR_END = 0x00aa00 // Green for end location highlight
 export const COLOR_EMPTY = 0xcccccc // Light gray for empty cells
+// Minimum time (in ms) that must elapse between player moves
+export const MOVE_THROTTLE_MS = 100

--- a/tests/Player.test.ts
+++ b/tests/Player.test.ts
@@ -1,0 +1,81 @@
+import type { Maze } from '@/game/Maze'
+import { MOVE_THROTTLE_MS } from '@/game/constants'
+import type { GameManager as GameManagerType } from '@/game/GameManager'
+
+// Mock Phaser to avoid initializing the full engine during tests
+jest.mock('phaser', () => ({
+  default: { GameObjects: { Rectangle: class { setOrigin() {}; setDepth() {}; destroy() {}; setPosition() {}; x = 0; y = 0 } } },
+  Events: { EventEmitter: class { emit() {}; on() {}; removeListener() {} } }
+}))
+
+jest.useFakeTimers()
+
+describe('Player movement', () => {
+  let scene: any
+  let maze: jest.Mocked<Maze>
+  let incrementSteps: jest.Mock
+  let player: any
+  let PlayerCtor: any
+
+  beforeEach(async () => {
+    scene = {
+      scale: { width: 64, height: 64 },
+      add: {
+        rectangle: jest.fn().mockReturnValue({
+          setOrigin: jest.fn(),
+          setDepth: jest.fn(),
+          destroy: jest.fn(),
+          setPosition: jest.fn(),
+          x: 0,
+          y: 0
+        })
+      },
+      tweens: { add: jest.fn() },
+      time: { delayedCall: jest.fn() },
+      scene: { get: jest.fn(), restart: jest.fn() }
+    }
+
+    maze = {
+      isMoveAllowed: jest.fn().mockReturnValue(true),
+      getEnd: jest.fn().mockReturnValue({ x: 99, y: 99 })
+    } as unknown as jest.Mocked<Maze>
+
+    incrementSteps = jest.fn()
+    const gm = { incrementSteps } as unknown as GameManagerType
+    jest.spyOn((await import('@/game/GameManager')).GameManager, 'getInstance').mockReturnValue(gm)
+
+    const mod = await import('@/game/Player')
+    PlayerCtor = mod.Player
+    player = new PlayerCtor(scene)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('moves when allowed and increments steps', () => {
+    expect(player.cell).toEqual({ x: 2, y: 2 })
+
+    player.moveBy(1, 0, maze)
+
+    expect(player.cell).toEqual({ x: 3, y: 2 })
+    expect(incrementSteps).toHaveBeenCalled()
+  })
+
+  it('throttles rapid movement', () => {
+    let now = MOVE_THROTTLE_MS
+    jest.spyOn(Date, 'now').mockImplementation(() => now)
+
+    player.moveBy(1, 0, maze)
+    expect(player.cell).toEqual({ x: 3, y: 2 })
+
+    now += MOVE_THROTTLE_MS - 10
+    player.moveBy(1, 0, maze)
+    // Cell should remain unchanged because of throttle
+    expect(player.cell).toEqual({ x: 3, y: 2 })
+
+    now += 20
+    player.moveBy(1, 0, maze)
+    expect(player.cell).toEqual({ x: 4, y: 2 })
+  })
+})


### PR DESCRIPTION
## Summary
- throttle player moveBy to limit move rate
- expose throttle constant
- add unit tests covering player movement and throttling

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_686f3375857c832085e7243d39aea325